### PR TITLE
Implement login and user-specific sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Simple mobile-friendly web application to log gym workouts. Backend uses Node.js
    ```
 3. Open `http://localhost:3000` in your browser.
 
+Log in using one of the predefined users:
+* **emanuele** / **ghisa**
+* **SBP** / **ghisa**
+* **dino** / **ghisa**
+
 The SQLite database file `gym.db` will be created automatically in the project directory.
 
 ## Docker

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.18.2",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "express-session": "^1.17.3",
+    "bcrypt": "^5.1.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
 <body>
   <div class="container">
     <h1>Gym Session Log</h1>
+    <button id="logoutBtn" style="float:right">Logout</button>
     <form id="sessionForm">
       <label for="date">Date:</label>
       <input type="date" id="date" required>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Login</h1>
+    <form id="loginForm">
+      <label for="username">Username:</label>
+      <input type="text" id="username" required>
+      <label for="password">Password:</label>
+      <input type="password" id="password" required>
+      <button type="submit">Login</button>
+    </form>
+    <p id="error" style="color:red"></p>
+  </div>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/public/login.js
+++ b/public/login.js
@@ -1,0 +1,17 @@
+const form = document.getElementById('loginForm');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.ok) {
+    window.location.href = '/';
+  } else {
+    const data = await res.json();
+    document.getElementById('error').innerText = data.error || 'Login failed';
+  }
+});

--- a/public/script.js
+++ b/public/script.js
@@ -1,5 +1,9 @@
 async function fetchSessions() {
   const res = await fetch('/api/sessions');
+  if (res.status === 401) {
+    window.location.href = '/login.html';
+    return;
+  }
   const data = await res.json();
   const tbody = document.querySelector('#sessionsTable tbody');
   tbody.innerHTML = '';
@@ -19,9 +23,18 @@ document.getElementById('sessionForm').addEventListener('submit', async e => {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ date, activity, duration })
+  }).then(res => {
+    if (res.status === 401) {
+      window.location.href = '/login.html';
+    }
   });
   e.target.reset();
   fetchSessions();
 });
 
 window.onload = fetchSessions;
+
+document.getElementById('logoutBtn').addEventListener('click', async () => {
+  await fetch('/api/logout', { method: 'POST' });
+  window.location.href = '/login.html';
+});

--- a/server.js
+++ b/server.js
@@ -1,41 +1,105 @@
 const express = require('express');
 const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
+const session = require('express-session');
+const bcrypt = require('bcrypt');
 
 const PORT = process.env.PORT || 3000;
 const DB_FILE = process.env.DB_FILE || 'gym.db';
+const SESSION_SECRET = process.env.SESSION_SECRET || 'secret-key';
 
 const app = express();
 app.use(express.json());
+app.use(session({
+  secret: SESSION_SECRET,
+  resave: false,
+  saveUninitialized: false
+}));
 app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/', (req, res) => {
+  if (!req.session.userId) {
+    return res.redirect('/login.html');
+  }
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
 
 // Initialize SQLite database
 const db = new sqlite3.Database(DB_FILE);
 
 db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL
+  )`);
+
   db.run(`CREATE TABLE IF NOT EXISTS sessions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
     date TEXT NOT NULL,
     activity TEXT NOT NULL,
-    duration INTEGER
+    duration INTEGER,
+    FOREIGN KEY(user_id) REFERENCES users(id)
   )`);
+
+  // Insert default users if none exist
+  const defaultUsers = [
+    { username: 'emanuele', password: 'ghisa' },
+    { username: 'SBP', password: 'ghisa' },
+    { username: 'dino', password: 'ghisa' }
+  ];
+  db.get('SELECT COUNT(*) as count FROM users', async (err, row) => {
+    if (err) return console.error(err);
+    if (row.count === 0) {
+      for (const u of defaultUsers) {
+        const hash = await bcrypt.hash(u.password, 10);
+        db.run('INSERT INTO users (username, password) VALUES (?, ?)', [u.username, hash]);
+      }
+    }
+  });
 });
 
 // API routes
-app.get('/api/sessions', (req, res) => {
-  db.all('SELECT * FROM sessions ORDER BY date DESC', (err, rows) => {
+function ensureLoggedIn(req, res, next) {
+  if (!req.session.userId) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  next();
+}
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  db.get('SELECT * FROM users WHERE username = ?', [username], async (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(401).json({ error: 'Invalid credentials' });
+    const match = await bcrypt.compare(password, row.password);
+    if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+    req.session.userId = row.id;
+    res.json({ success: true });
+  });
+});
+
+app.post('/api/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.json({ success: true });
+  });
+});
+
+app.get('/api/sessions', ensureLoggedIn, (req, res) => {
+  db.all('SELECT * FROM sessions WHERE user_id = ? ORDER BY date DESC', [req.session.userId], (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json(rows);
   });
 });
 
-app.post('/api/sessions', (req, res) => {
+app.post('/api/sessions', ensureLoggedIn, (req, res) => {
   const { date, activity, duration } = req.body;
   if (!date || !activity) {
     return res.status(400).json({ error: 'date and activity are required' });
   }
-  db.run('INSERT INTO sessions (date, activity, duration) VALUES (?, ?, ?)',
-    [date, activity, duration || null],
+  db.run('INSERT INTO sessions (user_id, date, activity, duration) VALUES (?, ?, ?, ?)',
+    [req.session.userId, date, activity, duration || null],
     function(err) {
       if (err) return res.status(500).json({ error: err.message });
       res.json({ id: this.lastID, date, activity, duration });


### PR DESCRIPTION
## Summary
- add express-session and bcrypt dependencies
- set up user table and default users
- implement login and logout endpoints with session storage
- restrict session routes to logged in users
- add login page and logout support in UI
- document login credentials in README
- add default users emanuele, SBP, and dino with password "ghisa"

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684344d8e50c83228ff82505dd888881